### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,14 +77,5 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../../laravel-cookies-consent/",
-            "options": {
-                "symlink": true
-            }
-        }
-    ]
+    "prefer-stable": true
 }


### PR DESCRIPTION
Remove local dependency for cookies consent plugin since it can be pulled from remote.

Reason: composer install fails, with 
```
Source path "../../laravel-cookies-consent" is not found for package scify/
```

NOTE: Maybe we should update composer.lock too.